### PR TITLE
Feat/7 특정 시점 상품 가격 조회 API 구현

### DIFF
--- a/src/main/java/aswemake/project/domain/product/controller/ProductController.java
+++ b/src/main/java/aswemake/project/domain/product/controller/ProductController.java
@@ -13,6 +13,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/products")
 @RestController
@@ -26,5 +28,33 @@ public class ProductController {
         admValidator.checkAdmin(user.getUsername());
         return ResponseEntity.status(HttpStatus.CREATED).body(productService.register(createProductRequestDto));
     }
+
+    @PatchMapping("/{productId}")
+    public ResponseEntity<ProductResponseDto> modify(@AuthenticationPrincipal User user,
+                                                     @Valid @RequestBody ModifyProductPriceRequestDto modifyProductPriceRequestDto,
+                                                     @PathVariable("productId") Long productId) {
+        admValidator.checkAdmin(user.getUsername());
+        return ResponseEntity.ok(productService.modify(productId, modifyProductPriceRequestDto));
+    }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ProductResponseDto> delete(@AuthenticationPrincipal User user,
+                                                     @PathVariable("productId") Long productId) {
+        admValidator.checkAdmin(user.getUsername());
+        productService.delete(productId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/price")
+    public ResponseEntity<Integer> getProductPriceAtSpecificTime(
+            @RequestParam("productId") Long productId,
+            @RequestParam("timestamp") LocalDateTime timestamp) {
+
+        if(timestamp == null)
+            timestamp = LocalDateTime.now();
+
+        return ResponseEntity.ok(productService.getProductPriceAtSpecificTime(productId, timestamp));
+    }
+
 }
 

--- a/src/main/java/aswemake/project/domain/product/entity/Product.java
+++ b/src/main/java/aswemake/project/domain/product/entity/Product.java
@@ -21,6 +21,10 @@ public class Product extends BaseEntity {
     @Column(name = "price", nullable = false)
     private int price;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_snapshot")
+    private ProductSnapshot productSnapshot;
+
     public static Product create(CreateProductRequestDto createProductRequestDto){
         return Product.builder()
                 .productName(createProductRequestDto.getProductName())
@@ -30,5 +34,11 @@ public class Product extends BaseEntity {
 
     public void modifyPrice(int price){
         this.price = price;
+    }
+
+    public void exchangeSnapshot(ProductSnapshot productSnapshot){
+        if(this.productSnapshot != null)
+            this.productSnapshot.expire();
+        this.productSnapshot = productSnapshot;
     }
 }

--- a/src/main/java/aswemake/project/domain/product/entity/ProductSnapshot.java
+++ b/src/main/java/aswemake/project/domain/product/entity/ProductSnapshot.java
@@ -1,0 +1,45 @@
+package aswemake.project.domain.product.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductSnapshot {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "product_name", nullable = false)
+    private String productName;
+    @Column(name = "price", nullable = false)
+    private int price;
+    @Column(name = "from_date", nullable = false)
+    private LocalDateTime fromDate;
+    @Column(name = "to_date", nullable = false)
+    private LocalDateTime toDate;
+    @Column(name = "product_id", nullable = false)
+    private Long productId; //상품 식별에 사용
+
+    public static ProductSnapshot create(Product product){
+        return ProductSnapshot.builder()
+                .productId(product.getId())
+                .fromDate(product.getModifiedDate()) //마지막으로 수정된 날짜
+                .toDate(LocalDateTime.now().plusYears(100)) //임시 마감기한 (무제한)
+                .productName(product.getProductName())
+                .price(product.getPrice())
+                .build();
+    }
+
+    //기간 만료 (상품 가격 수정)
+    public void expire(){
+        this.toDate = LocalDateTime.now();
+    }
+}

--- a/src/main/java/aswemake/project/domain/product/repository/ProductSnapshotRepository.java
+++ b/src/main/java/aswemake/project/domain/product/repository/ProductSnapshotRepository.java
@@ -1,0 +1,15 @@
+package aswemake.project.domain.product.repository;
+
+import aswemake.project.domain.product.entity.ProductSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDateTime;
+
+public interface ProductSnapshotRepository extends JpaRepository<ProductSnapshot, Long> {
+    @Query("select ps.price from ProductSnapshot as ps " +
+            "where ps.productId = :productId " +
+            "and :date >= ps.fromDate and :date < ps.toDate")
+    Integer getProductPriceAtSpecificTime(@Param("productId") Long productId,
+                                                                    @Param("date") LocalDateTime date);
+}

--- a/src/main/java/aswemake/project/domain/product/service/ProductService.java
+++ b/src/main/java/aswemake/project/domain/product/service/ProductService.java
@@ -1,20 +1,25 @@
 package aswemake.project.domain.product.service;
 
 import aswemake.project.domain.product.entity.Product;
+import aswemake.project.domain.product.entity.ProductSnapshot;
 import aswemake.project.domain.product.entity.request.CreateProductRequestDto;
 import aswemake.project.domain.product.entity.request.ModifyProductPriceRequestDto;
 import aswemake.project.domain.product.entity.response.ProductResponseDto;
 import aswemake.project.domain.product.exception.ProductNotFoundException;
 import aswemake.project.domain.product.repository.ProductRepository;
+import aswemake.project.domain.product.repository.ProductSnapshotRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProductService {
     private final ProductRepository productRepository;
+    private final ProductSnapshotRepository productSnapshotRepository;
 
     public Product findById(Long productId){
         return productRepository.findById(productId).orElseThrow(
@@ -25,6 +30,7 @@ public class ProductService {
     @Transactional
     public ProductResponseDto register(CreateProductRequestDto createProductRequestDto) {
         Product product = productRepository.save(Product.create(createProductRequestDto));
+        saveProductSnapshot(product);
         return ProductResponseDto.of(product);
     }
 
@@ -33,6 +39,7 @@ public class ProductService {
                                      ModifyProductPriceRequestDto modifyProductPriceRequestDto) {
         Product product = findById(productId);
         product.modifyPrice(modifyProductPriceRequestDto.getPrice());
+        saveProductSnapshot(product);
         return ProductResponseDto.of(product);
     }
 
@@ -41,4 +48,16 @@ public class ProductService {
         productRepository.deleteById(productId);
     }
 
+    private void saveProductSnapshot(Product product) {
+        ProductSnapshot snapshot = productSnapshotRepository.save(ProductSnapshot.create(product));
+        product.exchangeSnapshot(snapshot);
+    }
+
+    public Integer getProductPriceAtSpecificTime(Long productId, LocalDateTime timestamp) {
+        Integer productPriceAtSpecificTime = productSnapshotRepository.getProductPriceAtSpecificTime(productId, timestamp);
+        if(productPriceAtSpecificTime == null)
+            throw new ProductNotFoundException(timestamp+" 시점에 존재하는 " + productId+"번 상품은 존재하지 않습니다.");
+
+        return productPriceAtSpecificTime;
+    }
 }

--- a/src/test/java/aswemake/project/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/aswemake/project/domain/member/controller/MemberControllerTest.java
@@ -51,7 +51,7 @@ class MemberControllerTest {
                 .email("abcd1234").password("123456789").build();
 
         MvcResult result = mockMvc.perform(
-                        post("/api/member/join")
+                        post("/api/v1/member/join")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(request))
                 )
@@ -70,7 +70,7 @@ class MemberControllerTest {
                 .email("abcd@1234").password("1234").build();
 
         MvcResult result = mockMvc.perform(
-                        post("/api/member/join")
+                        post("/api/v1/member/join")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(request))
                 )
@@ -90,7 +90,7 @@ class MemberControllerTest {
                 .email("abcd@1234").password("123456789").build();
 
         MvcResult result = mockMvc.perform(
-                        post("/api/member/join")
+                        post("/api/v1/member/join")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(request))
                 )
@@ -109,7 +109,7 @@ class MemberControllerTest {
                 .email("abcd1234").password("123456789").build();
 
         MvcResult result = mockMvc.perform(
-                        post("/api/member/login")
+                        post("/api/v1/member/login")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(request))
                 )
@@ -129,7 +129,7 @@ class MemberControllerTest {
                 .email("abcd@1234").password("1234").build();
 
         MvcResult result = mockMvc.perform(
-                        post("/api/member/login")
+                        post("/api/v1/member/login")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(request))
                 )
@@ -158,7 +158,7 @@ class MemberControllerTest {
         // When, then
         ResultActions result = mockMvc
                 .perform(
-                        post("/api/member/login")
+                        post("/api/v1/member/login")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(request))
                 )

--- a/src/test/java/aswemake/project/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/aswemake/project/domain/product/controller/ProductControllerTest.java
@@ -20,7 +20,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -108,5 +111,26 @@ class ProductControllerTest {
 
         //then
         verify(productService).delete(productId);
+    }
+
+    @Test
+    @DisplayName("특정 시점의 상품 가격 조회 API")
+    @WithMockUser(username = "admin@naver.com")
+    void getProductPriceAtSpecificTime() throws Exception {
+        //given
+        Long productId = 1L;
+        LocalDateTime timestamp = LocalDateTime.of(2022, 12, 25, 0, 0);
+
+        //when
+        ResultActions result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/v1/products/price")
+                                .contentType(MediaType.APPLICATION_JSON)
+                .param("productId", String.valueOf(productId))
+                .param("timestamp", timestamp.toString()))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //then
+        verify(productService).getProductPriceAtSpecificTime(productId, timestamp);
     }
 }

--- a/src/test/java/aswemake/project/domain/product/entity/ProductTest.java
+++ b/src/test/java/aswemake/project/domain/product/entity/ProductTest.java
@@ -1,0 +1,53 @@
+package aswemake.project.domain.product.entity;
+
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+
+@Slf4j
+class ProductTest {
+
+    @Test
+    @DisplayName("exchangeSnapshot() - 스냅샷이 새로운 스냅샷으로 교체된다.")
+    void exchangeSnapshot() {
+        //given
+        Long productId = 1L;
+        String productName = "테스트 상품";
+        int price = 5000;
+        LocalDateTime timestamp = LocalDateTime.of(2222, 12, 25, 0, 0, 0,0);
+
+        Product product = Product.builder()
+                .id(productId)
+                .productName(productName)
+                .price(price)
+                .build();
+
+        ProductSnapshot snapshot1 = ProductSnapshot.builder()
+                .productId(productId)
+                .productName(productName)
+                .price(price)
+                .fromDate(LocalDateTime.now())
+                .toDate(timestamp) //2222.12.25
+                .build();
+        product.exchangeSnapshot(snapshot1); //최초 스냅샷 등록
+
+        ProductSnapshot snapshot2 = ProductSnapshot.builder()
+                .productId(productId)
+                .productName(productName)
+                .price(20000)
+                .fromDate(LocalDateTime.now())
+                .toDate(timestamp)
+                .build();
+
+        //when
+        log.info("snapshot1 기존 toDate : {} ", snapshot1.getToDate());
+        product.exchangeSnapshot(snapshot2);
+
+        //then
+        log.info("snapshot1 업데이트 toDate : {} ", snapshot1.getToDate());
+        Assertions.assertThat(snapshot1.getToDate()).isNotEqualTo(timestamp);
+        Assertions.assertThat(product.getProductSnapshot()).isEqualTo(snapshot2);
+    }
+}

--- a/src/test/java/aswemake/project/domain/product/repository/ProductSnapshotRepositoryTest.java
+++ b/src/test/java/aswemake/project/domain/product/repository/ProductSnapshotRepositoryTest.java
@@ -1,0 +1,62 @@
+package aswemake.project.domain.product.repository;
+
+import aswemake.project.domain.product.entity.ProductSnapshot;
+import aswemake.project.global.config.JpaAuditingConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@Slf4j
+class ProductSnapshotRepositoryTest {
+    @Autowired
+    protected ProductRepository productRepository;
+    @Autowired
+    protected ProductSnapshotRepository productSnapshotRepository;
+
+    @Test
+    @DisplayName("getProductPriceAtSpecificTime - 특정 시점의 상품 가격을 조회한다.")
+    void getProductPriceAtSpecificTime_fail() throws Exception {
+        //given
+        Long productId = 1L;
+        ProductSnapshot snapshot1 = ProductSnapshot.builder()
+                .productId(1L)
+                .productName("테스트용1")
+                .price(5000)
+                .fromDate(LocalDateTime.now().minusDays(1))
+                .toDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        ProductSnapshot snapshot2 = ProductSnapshot.builder()
+                .productId(1L)
+                .productName("테스트용2")
+                .price(10000)
+                .fromDate(LocalDateTime.now().minusDays(5))
+                .toDate(LocalDateTime.now().minusDays(1))
+                .build();
+
+        ProductSnapshot savedSnapshot1 = productSnapshotRepository.save(snapshot1);
+        ProductSnapshot savedSnapshot2 = productSnapshotRepository.save(snapshot2);
+
+        //when,then
+        log.info("현재 시간을 기준으로 상품 가격 검색");
+        Integer price1 = productSnapshotRepository.getProductPriceAtSpecificTime(productId, LocalDateTime.now());
+
+        log.info("3일전을 기준으로 상품 가격 검색");
+        Integer price2 = productSnapshotRepository.getProductPriceAtSpecificTime(productId, LocalDateTime.now().minusDays(3));
+
+        //then
+        Assertions.assertThat(price1).isNotNull();
+        Assertions.assertThat(price1).isEqualTo(snapshot1.getPrice());
+
+        Assertions.assertThat(price2).isNotNull();
+        Assertions.assertThat(price2).isEqualTo(snapshot2.getPrice());
+    }
+}


### PR DESCRIPTION
## 개발 내용
- [x] ProductSnapshot 구현
- [x] 상품 생성,수정 시 ProductSnapshot이 저장되도록 서비스 로직 변경
- [x] 특정 시점 상품 가격 조회 API 개발
- [x] 기존 테스트 코드 수정
- [x] 특정 시점 상품 가격 조회 관련 테스트 코드 작성
---
### 고민 사항
특정 시점 상품에 대한 다른 정보도 가져오도록 변경될 수도 있다고 생각했습니다.
즉, 확장성을 고려하여 ProductSnapshot은 상품에 관한 모든 정보를 가지고 있게 설계했습니다.
또한 상품에 관한 모든 스냅 샷을 보게 될 상황은 없다고 생각했고, 가격 수정 시 스냅샷의 활동 기간을 닫아줘야 했기 때문에  @ManyToOne이 아닌 @OneToOne으로 현재 스냅샷만 연결하도록 설계하였습니다.

관련이슈 : #7 
